### PR TITLE
Adding unit tests for com.taobao.arthas.common

### DIFF
--- a/common/src/test/java/com/taobao/arthas/common/JavaVersionUtilsTest.java
+++ b/common/src/test/java/com/taobao/arthas/common/JavaVersionUtilsTest.java
@@ -1,0 +1,29 @@
+package com.taobao.arthas.common;
+
+import com.taobao.arthas.common.JavaVersionUtils;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+import java.util.Properties;
+
+public class JavaVersionUtilsTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Rule public final Timeout globalTimeout = new Timeout(10000);
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void javaVersionStrInput1OutputNull() {
+
+    // Arrange
+    final Properties props = new Properties();
+    props.setProperty("foo", "BAZ");
+
+    // Act and Assert result
+    Assert.assertNull(JavaVersionUtils.javaVersionStr(props));
+  }
+}

--- a/common/src/test/java/com/taobao/arthas/common/PlatformEnumTest.java
+++ b/common/src/test/java/com/taobao/arthas/common/PlatformEnumTest.java
@@ -1,0 +1,25 @@
+package com.taobao.arthas.common;
+
+import com.taobao.arthas.common.PlatformEnum;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+public class PlatformEnumTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Rule public final Timeout globalTimeout = new Timeout(10000);
+
+  // Test written by Diffblue Cover.
+  @Test
+  public void valueOfInputNotNullOutputIllegalArgumentException() {
+
+    // Act
+    thrown.expect(IllegalArgumentException.class);
+    PlatformEnum.valueOf("1234");
+
+    // The method is not expected to return due to exception thrown
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `com.taobao.arthas.common` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important.